### PR TITLE
Fixed camera ghosts causing lua errors when loading saves with them

### DIFF
--- a/lua/entities/hl_camera_ghost/cl_init.lua
+++ b/lua/entities/hl_camera_ghost/cl_init.lua
@@ -2,7 +2,7 @@ include("shared.lua")
 
 function ENT:DrawTranslucent()
 	local camera = self:GetParent()
-	if not camera then return end
+	if not IsValid(camera) then return end
 	if not camera:ShouldDraw() then return end
 
 	-- in all other cases, draw

--- a/lua/entities/hl_camera_ghost/init.lua
+++ b/lua/entities/hl_camera_ghost/init.lua
@@ -2,3 +2,6 @@ include("shared.lua")
 
 AddCSLuaFile( "cl_init.lua" )
 AddCSLuaFile( "shared.lua" )
+
+ENT.DisableDuplicator = true
+ENT.DoNotDuplicate  = true


### PR DESCRIPTION
Despite duplicator working with those, saves still were picking them up